### PR TITLE
fix: Support point releases

### DIFF
--- a/.github/workflows/update-formula.ps1
+++ b/.github/workflows/update-formula.ps1
@@ -1,7 +1,7 @@
-param([string]$ReleaseVersion = "1.9.0", [string]$Version = "v1.8.0")
+param([string]$ReleaseVersion = "1.8.0", [string]$Version = "1.8.1")
 
-$Version = $Version.Replace("v","")
 $ReleaseVersion = $ReleaseVersion.Replace("v","")
+$Version = $Version.Replace("v","")
 Write-Host "Updating bottle .tar.gz to $Version"
 
 # TODO - Refactor this if needed elsewhere?
@@ -9,7 +9,10 @@ Set-Location $PSScriptRoot/../../Formula
 $TargetFile = "trinsic-cli.rb"
 
 $ContainerInformation = (Get-Content -Path $TargetFile -Raw)
-$UpdatedContainerInfo = ([Regex]'(\d+\.\d+\.\d+)').Replace($ContainerInformation, $Version)
+# Update both container version and release version - the leading space prevents matching root_url
+$DownloadUrl = " url `"https://github.com/trinsic-id/sdk/releases/download/v$ReleaseVersion/trinsic-cli-$Version.tar.gz`""
+$UpdatedContainerInfo = ([Regex]"\surl\s`"(.*)`"").Replace($ContainerInformation, $DownloadUrl)
+Write-Host $UpdatedContainerInfo
 Set-Content $UpdatedContainerInfo -Path $TargetFile -NoNewline
 
 # Download relevant file

--- a/.github/workflows/update-formula.ps1
+++ b/.github/workflows/update-formula.ps1
@@ -1,6 +1,7 @@
-param([string]$Version = "v1.8.0")
+param([string]$ReleaseVersion = "1.9.0", [string]$Version = "v1.8.0")
 
 $Version = $Version.Replace("v","")
+$ReleaseVersion = $ReleaseVersion.Replace("v","")
 Write-Host "Updating bottle .tar.gz to $Version"
 
 # TODO - Refactor this if needed elsewhere?

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           githubToken: ${{ secrets.API_GITHUB_TOKEN }}
           overrideVersion: ${{ inputs.userVersion || inputs.callerVersion }}
-      - run: ./.github/workflows/update-bottle.ps1 -Version ${{ steps.setversion.outputs.packageVersion }}
+      - run: ./.github/workflows/update-formula.ps1 -ReleaseVersion ${{ steps.setversion.outputs.releaseVersion }} -Version ${{ steps.setversion.outputs.packageVersion }}
         shell: pwsh
       - name: Commit changes
         uses: EndBug/add-and-commit@v9

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+.idea/


### PR DESCRIPTION
* `PackageVersion` and `ReleaseVersion` can be different
* Renamed action to be more descriptive
* `.gitignore` Jetbrains folder

Tested against known-good `v1.8.0/1.9.1` as shown below:
![image](https://user-images.githubusercontent.com/16713623/219426547-f6b79756-b5c1-48ad-8dc2-733f311028fa.png)
